### PR TITLE
Code for mass-concentration relations

### DIFF
--- a/mass_concentration.py
+++ b/mass_concentration.py
@@ -120,6 +120,8 @@ def dolag_concentration(m200, z, cosmo):
     Halo masses must be given in physical units with factors of h
     divided out.
     """
+    m200 = np.asanyarray(m200)
+    z = np.asanyarray(z)
     m200 = u.Quantity(m200 * cosmo.h, u.solMass).value
     conc = 9.59 / (1 + z) * (m200 / 1e14)**-0.102
     return conc
@@ -133,15 +135,15 @@ def duffy_concentration(m200, z, cosmo):
     Parameters:
     ===========
 
-    m200: float or astropy.Quantity
+    m200: float, array_like or astropy.Quantity
         Mass of halo at 200rho_crit, [Msun] if float
-    z: float
+    z: float or array_like
         Halo redshift
     cosmo: astropy.cosmology
 
     Returns:
     ========
-    conc: float
+    conc: float or array
         Halo concentration
 
     Notes:
@@ -150,6 +152,8 @@ def duffy_concentration(m200, z, cosmo):
     divided out.
     """
 
+    m200 = np.asanyarray(m200)
+    z = np.asanyarray(z)
     m200 = u.Quantity(m200 * cosmo.h, u.solMass)
     a = 5.71
     b = -0.084

--- a/mass_concentration.py
+++ b/mass_concentration.py
@@ -71,6 +71,30 @@ def mdelta_to_mdelta(m, func, overdensity_in, overdensity_out, args=()):
 
 
 def mdelta_to_m200(m, func, overdensity, args=()):
+    """
+    Convenience function for mdelta_to_mdelta with output overdensity 200.
+
+    Parameters:
+    ===========
+    m: float or astropy.Quantity
+        mass of halo
+    func: callable func(m200c, *args)
+        Mass-concentration scaling relation
+    overdensity: float
+        Overdensity in units of rho_crit at which halo mass is set
+    args: tuple, optional
+        Extra arguments passed to func, i.e., ``f(x, *args)``.
+
+    Returns:
+    ========
+    m200: astropy.Quantity
+        mass of halo at 200 times critical overdensity
+
+    Notes:
+    ======
+    Halo masses must be given in physical units with factors of h
+    divided out.
+    """
     return mdelta_to_mdelta(m, func, overdensity, 200, args)
 
 

--- a/mass_concentration.py
+++ b/mass_concentration.py
@@ -56,9 +56,8 @@ def mdelta_to_mdelta(m, func, overdensity_in, overdensity_out, args=()):
         mass of halo at Delta times critical overdensity
 
     Notes:
-    ======
-    Halo masses must be given in physical units with factors of h
-    divided out.
+    ====== 
+    Halo masses must be given in units expected by the M-c relation.
     """
     m_in = u.Quantity(m, u.solMass)
     delta_ratio = overdensity_in / overdensity_out
@@ -92,8 +91,7 @@ def mdelta_to_m200(m, func, overdensity, args=()):
 
     Notes:
     ======
-    Halo masses must be given in physical units with factors of h
-    divided out.
+    Halo masses must be given in units expected by the M-c relation.
     """
     return mdelta_to_mdelta(m, func, overdensity, 200, args)
 

--- a/mass_concentration.py
+++ b/mass_concentration.py
@@ -15,7 +15,7 @@ def _diff_c(c1, c0, delta_ratio):
 
 def _findc(c0, overdensity_in, overdensity_out):
     delta_ratio = overdensity_out / overdensity_in    
-    return opt.brentq(_diff_c, .1, 100, args=(c0, delta_ratio))
+    return opt.brentq(_diff_c, .01, 1000, args=(c0, delta_ratio))
 
 def _delta_fac(c):
     return np.log(1 + c) - c / (1 + c)
@@ -60,9 +60,12 @@ def mdelta_to_mdelta(m, func, overdensity_in, overdensity_out, args=()):
     Halo masses must be given in units expected by the M-c relation.
     """
     m_in = u.Quantity(m, u.solMass)
+    if overdensity_in == overdensity_out:
+        # brentq will fail for identical
+        return m_in
     delta_ratio = overdensity_in / overdensity_out
-    m_min = m_in / (delta_ratio * 5)
-    m_max = m_in * (delta_ratio * 5)
+    m_min = u.Quantity(1e5, u.solMass)
+    m_max = u.Quantity(1e25, u.solMass)
     mdelta = opt.brentq(_find_m200, m_min.value, m_max.value,
                        args=(func, overdensity_in, overdensity_out, m_in) \
                         + args)

--- a/mass_concentration.py
+++ b/mass_concentration.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+from __future__ import division
+
+import sys
+
+import numpy as np
+from scipy import optimize as opt
+
+from astropy import units as u
+from astropy import cosmology
+
+def _diff_c(c1, c0, delta_ratio):
+    return _delta_fac(c0) / _delta_fac(c1) - delta_ratio * (c0 / c1)**3
+
+def _findc(c0, overdensity_in, overdensity_out):
+    delta_ratio = overdensity_out / overdensity_in    
+    return opt.brentq(_diff_c, .1, 100, args=(c0, delta_ratio))
+
+def _delta_fac(c):
+    return np.log(1 + c) - c / (1 + c)
+
+def _find_m200(m200, *args):
+    func = args[0]
+    overdensity_in = args[1]
+    overdensity_out = args[2]
+    m_in = args[3]
+    my_args = args[4:]
+    c0 = func(m200, *my_args)
+    c1 = _findc(c0, overdensity_in, overdensity_out)
+    return m200/m_in.value - _delta_fac(c0) / _delta_fac(c1)
+
+
+def mdelta_to_mdelta(m, func, overdensity_in, overdensity_out, args=()):
+    """
+    Convert the a mass given in a variable overdensity with respect to
+    the critical density to the mass in another overdensity wrt the
+    critical density following a fixed mass concentration relation.
+
+    Parameters:
+    ===========
+    m: float or astropy.Quantity
+        mass of halo
+    func: callable func(m200c, *args)
+        Mass-concentration scaling relation
+    overdensity_in: float
+        Overdensity in units of rho_crit at which halo mass is set
+    overdensity_out: float
+        Overdensity in units of rho_crit at which halo mass is desired
+    args: tuple, optional
+        Extra arguments passed to func, i.e., ``f(x, *args)``.
+
+    Returns:
+    ========
+    mdelta: astropy.Quantity
+        mass of halo at Delta times critical overdensity
+
+    Notes:
+    ======
+    Halo masses must be given in physical units with factors of h
+    divided out.
+    """
+    m_in = u.Quantity(m, u.solMass)
+    delta_ratio = overdensity_in / overdensity_out
+    m_min = m_in / (delta_ratio * 5)
+    m_max = m_in * (delta_ratio * 5)
+    mdelta = opt.brentq(_find_m200, m_min.value, m_max.value,
+                       args=(func, overdensity_in, overdensity_out, m_in) \
+                        + args)
+    return u.Quantity(mdelta, u.solMass)
+
+
+def mdelta_to_m200(m, func, overdensity, args=()):
+    return mdelta_to_mdelta(m, func, overdensity, 200, args)
+
+
+def dolag_concentration(m200, z, cosmo):
+    """
+    Compute the concentration of the Dolag et al. (2004)
+    mass concentration relation for a standard LCDM universe.
+
+    Parameters:
+    ===========
+
+    m200: astropy.Quantity
+        Mass of halo at 200rho_crit
+    z: float
+        Halo redshift
+    cosmo: astropy.cosmology
+
+    Returns:
+    ========
+    conc: float
+        Halo concentration
+
+    Notes:
+    ======
+    Halo masses must be given in physical units with factors of h
+    divided out.
+    """
+    m200 = u.Quantity(m200 * cosmo.h, u.solMass).value
+    conc = 9.59 / (1 + z) * (m200 / 1e14)**-0.102
+    return conc
+
+  
+def duffy_concentration(m200, z, cosmo):
+    """
+    Compute the concentration of the Duffy et al. (2008)
+    mass concentration relation for 200 rho_crit.
+
+    Parameters:
+    ===========
+
+    m200: float or astropy.Quantity
+        Mass of halo at 200rho_crit, [Msun] if float
+    z: float
+        Halo redshift
+    cosmo: astropy.cosmology
+
+    Returns:
+    ========
+    conc: float
+        Halo concentration
+
+    Notes:
+    ======
+    Halo masses must be given in physical units with factors of h
+    divided out.
+    """
+
+    m200 = u.Quantity(m200 * cosmo.h, u.solMass)
+    a = 5.71
+    b = -0.084
+    c = -0.47
+    m_pivot = u.Quantity(2e12, u.solMass)
+    conc = a * (m200 / m_pivot)**b * (1 + z)**c
+    return conc.value
+

--- a/tests/test_mass_concentration.py
+++ b/tests/test_mass_concentration.py
@@ -6,7 +6,7 @@ from numpy.testing.decorators import knownfailureif
 
 import astropy.cosmology
 from astropy import units as u
-from astropy.tests.helper import quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose
 
 import mass_concentration
 from nfw import NFW
@@ -62,28 +62,28 @@ class TestMc(TestCase):
         # common cases:
         mdelta = mass_concentration.mdelta_to_mdelta(5e14, func, 200, 500,
                                                      (0.3, self._cosmo))
-        assert(quantity_allclose(mdelta,
-                                 u.Quantity(397021380489815.56, u.solMass)))
+        assert_quantity_allclose(mdelta,
+                                 u.Quantity(397021380489815.56, u.solMass))
         mdelta = mass_concentration.mdelta_to_mdelta(1e14, func, 2500, 500,
                                                      (0, self._cosmo))    
-        assert(quantity_allclose(mdelta,
-                                 u.Quantity(155627379902287.5, u.solMass)))
+        assert_quantity_allclose(mdelta,
+                                 u.Quantity(155627379902287.5, u.solMass))
         # extreme cases
         mdelta = mass_concentration.mdelta_to_mdelta(1e14, func, 199, 200,
                                                      (1, self._cosmo))
-        assert(quantity_allclose(mdelta,
-                                 u.Quantity(99840165385091.89, u.solMass)))
+        assert_quantity_allclose(mdelta,
+                                 u.Quantity(99840165385091.89, u.solMass))
         mdelta = mass_concentration.mdelta_to_mdelta(1e14, func, 200, 200,
                                                      (1, self._cosmo))
         assert_equal(mdelta.value, 1e14)
         mdelta = mass_concentration.mdelta_to_mdelta(1e15, func, 2500, 50,
                                                      (0, self._cosmo))
-        assert(quantity_allclose(mdelta,
-                                 u.Quantity(6297248192424681.0, u.solMass)))
+        assert_quantity_allclose(mdelta,
+                                 u.Quantity(6297248192424681.0, u.solMass))
         mdelta = mass_concentration.mdelta_to_mdelta(1e9, func, 50, 2500,
                                                      (1, self._cosmo))
-        assert(quantity_allclose(mdelta,
-                                 u.Quantity(581928261.3835365, u.solMass)))
+        assert_quantity_allclose(mdelta,
+                                 u.Quantity(581928261.3835365, u.solMass))
         # Consistency
         z = 0.3
         m_in = u.Quantity(5e14, u.solMass)
@@ -92,7 +92,7 @@ class TestMc(TestCase):
         c = func(mdelta, z, self._cosmo)
         nfw = NFW(mdelta, c, z)
         m_out = nfw.mass_Delta(500)
-        assert(quantity_allclose(m_in, m_out))
+        assert_quantity_allclose(m_in, m_out)
 
     def test_mdelta_to_m200(self):
         # consistency with mdelta_to_mdelta
@@ -105,4 +105,4 @@ class TestMc(TestCase):
         md2 = mass_concentration.mdelta_to_mdelta(m_in, func,
                                                   delta_in, 200,
                                                   (z, self._cosmo))
-        assert(quantity_allclose(md1, md2))
+        assert_quantity_allclose(md1, md2)

--- a/tests/test_mass_concentration.py
+++ b/tests/test_mass_concentration.py
@@ -6,7 +6,14 @@ from numpy.testing.decorators import knownfailureif
 
 import astropy.cosmology
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose
+try:
+    from astropy.tests.helper import assert_quantity_allclose
+except ImportError:
+    # Monkey patching failing travis test for numpy-1.8
+    def assert_quantity_allclose(x, y):
+        x = x.to(y.unit)
+        np.testing.assert_allclose(x.value, y.value)
+    
 
 import mass_concentration
 from nfw import NFW

--- a/tests/test_mass_concentration.py
+++ b/tests/test_mass_concentration.py
@@ -1,0 +1,53 @@
+import numpy as np
+from numpy.testing import (TestCase, assert_array_equal, assert_equal,
+                           assert_almost_equal, assert_array_almost_equal,
+                           assert_raises)
+from numpy.testing.decorators import knownfailureif
+
+import astropy.cosmology
+from astropy import units as u
+
+import mass_concentration
+
+class TestMc(TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls._cosmo = astropy.cosmology.FlatLambdaCDM(70, 0.3, Tcmb0=0)
+        astropy.cosmology.default_cosmology.set(cls._cosmo)
+
+    def test_duffy_concentration(self):
+        m200 = 1e13, 5e13, 1e14, 1e15
+        zl = 1, 0.5, 1, 0.3
+        result = (3.71065258,
+                  3.71071859,
+                  3.05809022,
+                  3.08589409)
+        c = mass_concentration.duffy_concentration(m200, zl, self._cosmo)
+        assert_almost_equal(c, result)
+        assert(isinstance(c, np.ndarray))
+        # Assure results stay the same 
+        m200 = u.Quantity(m200, u.solMass)
+        c = mass_concentration.duffy_concentration(m200, zl, self._cosmo)
+        assert_almost_equal(c, result)
+        c = mass_concentration.duffy_concentration(m200[0], zl[0],
+                                                   self._cosmo)
+        assert(isinstance(c, float))
+
+    def test_dolag_concentration(self):
+        m200 = 1e13, 5e13, 1e14, 1e15
+        zl = 1, 0.5, 1, 0.3
+        result = (6.28910161,
+                  7.11594213,
+                  4.97265823,
+                  6.04888398)
+        c = mass_concentration.dolag_concentration(m200, zl, self._cosmo)
+        assert_almost_equal(c, result)
+        assert(isinstance(c, np.ndarray))
+        # Assure results stay the same 
+        m200 = u.Quantity(m200, u.solMass)
+        c = mass_concentration.dolag_concentration(m200, zl, self._cosmo)
+        assert_almost_equal(c, result)
+        c = mass_concentration.dolag_concentration(m200[0], zl[0],
+                                                   self._cosmo)
+        assert(isinstance(c, float))
+        

--- a/tests/test_mass_concentration.py
+++ b/tests/test_mass_concentration.py
@@ -93,3 +93,16 @@ class TestMc(TestCase):
         nfw = NFW(mdelta, c, z)
         m_out = nfw.mass_Delta(500)
         assert(quantity_allclose(m_in, m_out))
+
+    def test_mdelta_to_m200(self):
+        # consistency with mdelta_to_mdelta
+        m_in = 2e14
+        z = 0.2
+        func = mass_concentration.dolag_concentration
+        delta_in = 450
+        md1 = mass_concentration.mdelta_to_m200(m_in, func, delta_in,
+                                                (z, self._cosmo))
+        md2 = mass_concentration.mdelta_to_mdelta(m_in, func,
+                                                  delta_in, 200,
+                                                  (z, self._cosmo))
+        assert(quantity_allclose(md1, md2))

--- a/tests/test_mass_concentration.py
+++ b/tests/test_mass_concentration.py
@@ -6,8 +6,11 @@ from numpy.testing.decorators import knownfailureif
 
 import astropy.cosmology
 from astropy import units as u
+from astropy.tests.helper import quantity_allclose
 
 import mass_concentration
+from nfw import NFW
+
 
 class TestMc(TestCase):
     @classmethod
@@ -51,3 +54,42 @@ class TestMc(TestCase):
                                                    self._cosmo)
         assert(isinstance(c, float))
         
+    def test_mdelta_to_mdelta(self):
+        overdensity = 50, 100, 199, 200, 500, 2500
+        m_in = 1e9, 1e13, 1e14, 1e15, 1e16
+        z = 0, 0.5, 1
+        func = mass_concentration.dolag_concentration
+        # common cases:
+        mdelta = mass_concentration.mdelta_to_mdelta(5e14, func, 200, 500,
+                                                     (0.3, self._cosmo))
+        assert(quantity_allclose(mdelta,
+                                 u.Quantity(397021380489815.56, u.solMass)))
+        mdelta = mass_concentration.mdelta_to_mdelta(1e14, func, 2500, 500,
+                                                     (0, self._cosmo))    
+        assert(quantity_allclose(mdelta,
+                                 u.Quantity(155627379902287.5, u.solMass)))
+        # extreme cases
+        mdelta = mass_concentration.mdelta_to_mdelta(1e14, func, 199, 200,
+                                                     (1, self._cosmo))
+        assert(quantity_allclose(mdelta,
+                                 u.Quantity(99840165385091.89, u.solMass)))
+        mdelta = mass_concentration.mdelta_to_mdelta(1e14, func, 200, 200,
+                                                     (1, self._cosmo))
+        assert_equal(mdelta.value, 1e14)
+        mdelta = mass_concentration.mdelta_to_mdelta(1e15, func, 2500, 50,
+                                                     (0, self._cosmo))
+        assert(quantity_allclose(mdelta,
+                                 u.Quantity(6297248192424681.0, u.solMass)))
+        mdelta = mass_concentration.mdelta_to_mdelta(1e9, func, 50, 2500,
+                                                     (1, self._cosmo))
+        assert(quantity_allclose(mdelta,
+                                 u.Quantity(581928261.3835365, u.solMass)))
+        # Consistency
+        z = 0.3
+        m_in = u.Quantity(5e14, u.solMass)
+        mdelta = mass_concentration.mdelta_to_mdelta(5e14, func, 500, 200,
+                                                     (z, self._cosmo))
+        c = func(mdelta, z, self._cosmo)
+        nfw = NFW(mdelta, c, z)
+        m_out = nfw.mass_Delta(500)
+        assert(quantity_allclose(m_in, m_out))


### PR DESCRIPTION
Implement Duffy and Dolag M-c relations, and conversions between input masses at different overdensities for halos following an M-c relation. Closes #5 